### PR TITLE
added check for file existence

### DIFF
--- a/src/Maker.php
+++ b/src/Maker.php
@@ -31,7 +31,10 @@ class Maker
 
     protected function prep($locale)
     {
-        $locale = $locale ?: 'en';
+        if ( file_exists(realpath(__DIR__."/../data/$locale.php")) === false ) {
+            $locale = 'en';
+        }
+        
         $this->countries = collect(require realpath(__DIR__."/../data/$locale.php"));             
     }
 }


### PR DESCRIPTION
I ran into this issue passing the locale in uppercase. On an case insensitive file system there were no problems loading the locale file. On a case sensitive file system an exception was thrown. I think it's always saver to do a file_exists check before requiring files.